### PR TITLE
Fixed typo in cd command

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ git clone https://github.com/OpenZWave/open-zwave-control-panel.git
 ```
 7. Edit the Makefile
 ``` bash
-cd openzwave-control-panel
+cd open-zwave-control-panel
 
 # for Linux uncomment out next two lines
 LIBZWAVE := $(wildcard $(OPENZWAVE)/cpp/lib/linux/*.a)


### PR DESCRIPTION
The git clone command brings down "open-zwave-control-panel", the cd command was missing a dash.
